### PR TITLE
split optimization run into subfunctions and implemented 90-10 split

### DIFF
--- a/src/bagofwords.py
+++ b/src/bagofwords.py
@@ -24,7 +24,6 @@
 # SOFTWARE.
 
 import logging
-import pathos.multiprocessing as mp
 import os
 from pathlib import Path
 import re
@@ -105,8 +104,8 @@ _DEFAULT_CONFIG = {
         # NOTE: Currently, 'random-forest' is the only working option.
         'type': 'random-forest',
         'args': {
-            'n_estimators': 100,
-            'max_features': 10000,
+            'n_estimators': 50,
+            'max_features': 20000,
             'n_jobs':       4,
         },
     },
@@ -114,12 +113,12 @@ _DEFAULT_CONFIG = {
         # Type of the run, one of {'optimization', 'submission'}
         # NOTE: Currently, only optimization run is implemented.
         'type':          'optimization',
-        'number_splits': 5,
+        'number_splits': 3,
         'remove_stopwords': False,
         'cache_clean': True,
         'test_10': True,
         'random': 40,
-        'alpha': 0.6,
+        'alpha': 0.3,
     },
     'bagofwords': {},
     'word2vec': {
@@ -245,11 +244,10 @@ def clean_up_reviews(reviews: Iterable[str],
     if not compute_only and Path(clean_file).exists():
         return _read_data_from(clean_file)['review'].values
     logging.info('Cleaning and parsing the reviews...')
-    with mp.ProcessingPool() as pool:
-        review = np.array(pool.map(
+    review = np.array(list(map(
             lambda x: ' '.join(
                 ReviewPreprocessor.review2wordlist(x, remove_stopwords)),
-            reviews))
+            reviews)))
     if not compute_only:
         logging.info('Saving clean data to file "cleanReviews.tsv" ...')
         pd.DataFrame(data={"review": review}) \

--- a/src/bagofwords.py
+++ b/src/bagofwords.py
@@ -104,8 +104,8 @@ _DEFAULT_CONFIG = {
         # NOTE: Currently, 'random-forest' is the only working option.
         'type': 'random-forest',
         'args': {
-            'n_estimators': 50,
-            'max_features': 20000,
+            'n_estimators': 100,
+            # 'max_features': 20000,
             'n_jobs':       4,
         },
     },
@@ -117,8 +117,8 @@ _DEFAULT_CONFIG = {
         'remove_stopwords': False,
         'cache_clean': True,
         'test_10': True,
-        'random': 40,
-        'alpha': 0.3,
+        'random': 42,
+        'alpha': 0.1,
     },
     'bagofwords': {},
     'word2vec': {

--- a/src/bagofwords.py
+++ b/src/bagofwords.py
@@ -356,7 +356,6 @@ def optimization_run(ids: Type[np.ndarray],
         reviews_test = reviews[test_index]
         sentiments_train = sentiments[train_index]
         sentiments_test = sentiments[test_index]
-        ids_train = ids[train_index]
 
     predictions = np.zeros(sentiments_train.shape, dtype=np.bool_)
     scores = np.zeros((n_splits,), dtype=np.float32)
@@ -402,7 +401,7 @@ def optimization_run(ids: Type[np.ndarray],
         logging.info('Overall accuracy on left-out data from 90-10 split was {}'
                      .format(np.mean(score_10)))
 
-    bookkeeping(ids_train,
+    bookkeeping(ids[train_index],
                 predictions,
                 reviews_train,
                 sentiments_train,


### PR DESCRIPTION
Okay, I tried my best to split the optimization run function, not sure if I succeeded :)
Some remarks:
1. For now the script creates a 90-10 split by actually dividing the data according to the indexes given by StratifiedShuffleSplit. In the crossvalidation folds I use indexing only. Is there a way to index and indexed array?? Because this would save lines 355-358.

2. I thought it was a good idea to create the bookkeeping function which writes results to files. I think this might be better called in the main() function, what do you think?

3. Not sure how compatible StratifiedShuffleSplit is with Lilo. I did not know how to check for the functionality in older packages, but probably this has to be adjusted for the different python versions as well.